### PR TITLE
Add convenience URL for Slack invites

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -52,3 +52,7 @@ https://docs.google.com/document/d/1DXEVEfk4x1qN6QgIcb2PjZwU4m7W6ib49wCdktMMjLw
 # team
 
 /team / 302
+
+# misc
+
+/slack-invite https://join.slack.com/t/bisq/shared_invite/enQtMjcwMDA3NTAyOTUxLTMwYmQ4NjcxNjBmNjVmNjExM2NmZDY2ZTQyOTI4MTQ2NGI1MWYzOWRhZThlOTZkZDVhYTJkY2VkZDBlMjczYTU 302


### PR DESCRIPTION
At https://bisq.network/slack-invite. Note that these invite URLs expire
after 30 days, so we'll need to update this link periodically. This link
expires on Dec 8th.